### PR TITLE
api/notes route is now pulling 20 random notes from the database

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,7 @@
 {
   "development": {
     "username": "root",
-    "password": "123",
+    "password": "",
     "database": "notes_db",
     "host": "localhost",
     "port": 3306,

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -1,13 +1,15 @@
 const db = require("../models");
-
+const Sequelize = require("sequelize");
 
 // Routes
 
-// GET route to get all notes
+// GET route to get random notes.  Returns dbNotes, which is an array of 20 random notes pulled from the database. 
 module.exports = function(app) {
   app.get("/api/notes", function(req, res) {
     // Finding all entries to the tables when used with no options
-    db.Note.findAll({}).then(function(dbNotes) {
+    db.Note.findAll({
+      order: Sequelize.literal('rand()'), limit: 20
+    }).then(function(dbNotes) {
       res.json(dbNotes);
     });
 


### PR DESCRIPTION
Changed our GET api/notes route to pull an array of 20 random notes from the database instead of all notes in the database.  api-routes.js now requires sequelize.  The limit key can be changed if we need to pull a different number of notes, but I believe 20 should be the max (5x4 for desktop).