### PR TITLE
Adding modal.handlebars to showcase partial functionality

### DIFF
--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -7,7 +7,7 @@
         <button id="note-btn-exit" onclick="closeNoteAnim()">X</button>
 
         <div id="note-display__new">
-
+            {{> modal }}
         </div>
 
         <div id="note-display__read">

--- a/views/partials/modal.handlebars
+++ b/views/partials/modal.handlebars
@@ -1,0 +1,1 @@
+<h1>Template text from (/partials/modal.handlebars) referenced in index.handlebars line 10</h1>


### PR DESCRIPTION
This is a small addition to show the functionality of dynamically adding text to each modal.

If wallnote.handlebars was included for future use of this functionality, feel free to reject this PR so edits can be made.